### PR TITLE
Use u32::{from_le_bytes, to_le_bytes}

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,18 +16,6 @@ pub fn hash(string: &[u8]) -> u32 {
     h.0
 }
 
-/// Get array of bytes from an `u32`.
-#[inline]
-pub fn pack(v: u32) -> [u8; 4] {
-    [v as u8, (v >> 8) as u8, (v >> 16) as u8, (v >> 24) as u8]
-}
-
-/// Get an `u32` from an array of 4 bytes.
-#[inline]
-pub fn unpack(v: [u8; 4]) -> u32 {
-    (v[0] as u32) | ((v[1] as u32) << 8) | ((v[2] as u32) << 16) | ((v[3] as u32) << 24)
-}
-
 /// Represent an iterable of bytes as "lossy" `utf8` `String`.
 ///
 /// If the byte cannot be represented as an `utf8` character, it'll be replaced

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,5 +1,5 @@
 //! This module allows you to read from a CDB.
-use helpers::{hash, unpack};
+use helpers::hash;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use types::{Error, Result};
@@ -96,8 +96,8 @@ impl<'a, 'file: 'a, F: Read + Seek + 'file> Iterator for ItemIterator<'a, 'file,
             let mut chunk = self.reader.file.take(8);
             let _ = chunk.read(&mut buf);
         }
-        let k = unpack([buf[0], buf[1], buf[2], buf[3]]); // Key length
-        let v = unpack([buf[4], buf[5], buf[6], buf[7]]); // Value length
+        let k = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]); // Key length
+        let v = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]); // Value length
 
         let mut key: Vec<u8> = vec![];
         {
@@ -189,8 +189,8 @@ impl<'a, F: Read + Seek + 'a> Reader<'a, F> {
 
         for ix in 0..2048 / 8 {
             let i = ix * 8;
-            let k = unpack([buf[i], buf[i + 1], buf[i + 2], buf[i + 3]]);
-            let v = unpack([buf[i + 4], buf[i + 5], buf[i + 6], buf[i + 7]]);
+            let k = u32::from_le_bytes([buf[i], buf[i + 1], buf[i + 2], buf[i + 3]]);
+            let v = u32::from_le_bytes([buf[i + 4], buf[i + 5], buf[i + 6], buf[i + 7]]);
             sum += v >> 1;
             index.push((k, v));
         }
@@ -268,8 +268,8 @@ impl<'a, F: Read + Seek + 'a> Reader<'a, F> {
                     let mut chunk = self.file.take(8);
                     chunk.read_exact(&mut buf)?;
                 }
-                let rec_h = unpack([buf[0], buf[1], buf[2], buf[3]]);
-                let rec_pos = unpack([buf[4], buf[5], buf[6], buf[7]]);
+                let rec_h = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+                let rec_pos = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
 
                 if rec_h == 0 {
                     // Key not in file.
@@ -281,8 +281,8 @@ impl<'a, F: Read + Seek + 'a> Reader<'a, F> {
                         let mut chunk = self.file.take(8);
                         chunk.read_exact(&mut buf)?;
                     }
-                    let klen = unpack([buf[0], buf[1], buf[2], buf[3]]);
-                    let dlen = unpack([buf[4], buf[5], buf[6], buf[7]]);
+                    let klen = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+                    let dlen = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
 
                     let mut buf: Vec<u8> = vec![];
                     {
@@ -329,8 +329,8 @@ impl<'a> Reader<'a, File> {
                         // EOF
                         break;
                     }
-                    let h = unpack([buf[0], buf[1], buf[2], buf[3]]);
-                    let pos = unpack([buf[4], buf[5], buf[6], buf[7]]);
+                    let h = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+                    let pos = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
                     index[(h & 0xff) as usize].push((h, pos));
                 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,5 +1,5 @@
 //! This module allows you to write to a CDB.
-use helpers::{hash, pack};
+use helpers::hash;
 use reader::Reader;
 use std::io::{Read, Seek, SeekFrom, Write};
 use types::Result;
@@ -67,8 +67,8 @@ impl<'a, F: Write + Read + Seek + 'a> Writer<'a, F> {
     pub fn put(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
         let file = self.file.as_mut().unwrap();
         let pos = file.seek(SeekFrom::Current(0))? as u32;
-        file.write_all(&pack(key.len() as u32))?;
-        file.write_all(&pack(value.len() as u32))?;
+        file.write_all(&(key.len() as u32).to_le_bytes())?;
+        file.write_all(&(value.len() as u32).to_le_bytes())?;
 
         file.write_all(key)?;
         file.write_all(value)?;
@@ -105,15 +105,15 @@ impl<'a, F: Write + Read + Seek + 'a> Writer<'a, F> {
                 length,
             ));
             for pair in ordered {
-                file.write_all(&pack(pair.0)).unwrap();
-                file.write_all(&pack(pair.1)).unwrap();
+                file.write_all(&(pair.0).to_le_bytes()).unwrap();
+                file.write_all(&(pair.1).to_le_bytes()).unwrap();
             }
         }
 
         file.seek(SeekFrom::Start(0)).unwrap();
         for pair in index {
-            file.write_all(&pack(pair.0)).unwrap();
-            file.write_all(&pack(pair.1)).unwrap();
+            file.write_all(&(pair.0).to_le_bytes()).unwrap();
+            file.write_all(&(pair.1).to_le_bytes()).unwrap();
         }
     }
 


### PR DESCRIPTION
They are available since Rust 1.32, released in January 2019.
